### PR TITLE
Device parameter fixes

### DIFF
--- a/src/hw_device_mgr/cia_301/config.py
+++ b/src/hw_device_mgr/cia_301/config.py
@@ -94,9 +94,6 @@ class CiA301Config:
             ix = (ix, 0)
         return self._model_sdos[self.model_id][ix]
 
-    def sdo_type(self, sdo):
-        return self.data_type_class.by_shared_name(sdo.data_type)
-
     #
     # Param read/write
     #

--- a/src/hw_device_mgr/cia_301/config.py
+++ b/src/hw_device_mgr/cia_301/config.py
@@ -208,7 +208,7 @@ class CiA301Config:
         return self._config
 
     def write_config_param_values(self):
-        for sdo, value in self.config["param_values"]:
+        for sdo, value in self.config["param_values"].items():
             self.download(sdo, value)
 
     #

--- a/src/hw_device_mgr/cia_301/tests/base_test_class.py
+++ b/src/hw_device_mgr/cia_301/tests/base_test_class.py
@@ -67,6 +67,7 @@ class BaseCiA301TestClass(BaseTestClass):
         those keys.
         """
         global_conf = self.load_yaml(self.global_config_yaml)
+        print(f"Loaded global config from {self.global_config_yaml}")
         for model_conf in global_conf:
             if "model_key" not in model_conf:
                 continue

--- a/src/hw_device_mgr/cia_301/tests/bogus_devices/device.yaml
+++ b/src/hw_device_mgr/cia_301/tests/bogus_devices/device.yaml
@@ -3,22 +3,22 @@
   position:  10
   params:
     605A-00h: 3
-    607D-01h:  -50000
-    607D-02h:  50000
+    607D-01h:  -50
+    607D-02h:  50
 - model_key:  bogus_servo
   bus:  0
   position:  11
   params:
     605A-00h: 3
-    607D-01h:  -40000
-    607D-02h:  40000
+    607D-01h:  -40
+    607D-02h:  40
 - model_key:  bogus_servo_2
   bus:  0
   position:  12
   params:
     605A-00h: 3
-    607D-01h:  -10000
-    607D-02h:  10000
+    607D-01h:  -10
+    607D-02h:  10
 - model_key:  bogus_io
   bus:  0
   position:  16

--- a/src/hw_device_mgr/cia_301/tests/test_config.py
+++ b/src/hw_device_mgr/cia_301/tests/test_config.py
@@ -59,3 +59,20 @@ class TestCiA301Config(BaseCiA301TestClass):
             val = obj.upload(sdo_ix)
             obj.download(sdo_ix, val + 1)
             assert obj.upload(sdo_ix) == val + 1
+
+    def test_write_config_param_values(self, obj, sdo_data):
+        # Test fixture data:  At least one config param value should
+        # be different from default to make this test meaningful.  (IO
+        # devices have no config values, so ignore those.)
+        something_different = False
+        for sdo_ix, conf_val in obj.config["param_values"].items():
+            dev_val = obj.upload(sdo_ix)
+            print(f"SDO {sdo_ix}:  device={dev_val}, config={conf_val}")
+            if dev_val != conf_val:
+                something_different = True
+            # something_different |= (dev_val != conf_val)
+        assert something_different or not obj.config["param_values"]
+
+        obj.write_config_param_values()
+        for sdo_ix, val in obj.config["param_values"].items():
+            assert obj.upload(sdo_ix) == val

--- a/src/hw_device_mgr/hal/tests/mock_hal.py
+++ b/src/hw_device_mgr/hal/tests/mock_hal.py
@@ -13,8 +13,11 @@ class MockHALPin(MockFixture):
         self.pname = pname
         self.ptype = ptype
         self.pdir = pdir
+
+    def _set_storage(self, storage):
+        # Init storage outside constructor to reduce test logging mess
         self.storage = storage
-        self.storage[pname] = 0
+        self.storage[self.pname] = 0
 
     def set(self, val):
         """Emulates `hal_pin.set()`"""
@@ -67,8 +70,9 @@ class MockHALComponent(MockFixture):
 
     def newpin(self, *args):
         """Emulates `hal_comp.newpin()`"""
-        mock_obj = MockHALPin.get_mock(*args, storage=self.pin_vals)
+        mock_obj = MockHALPin.get_mock(*args)
         pin = mock_obj.obj
+        pin._set_storage(self.pin_vals)
         self.pins[pin.pname] = mock_obj
         print(f"MockHALComponent {self.name}: newpin({args})")
         return mock_obj

--- a/src/hw_device_mgr/lcec/command.py
+++ b/src/hw_device_mgr/lcec/command.py
@@ -20,7 +20,7 @@ class LCECCommand(EtherCATCommand):
         """
         cmd_args = ["ethercat"] + list(args)
         if dry_run:
-            getattr(self.logger, "info")("Would run:  " + " ".join(cmd_args))
+            self.logger.info("Would run:  " + " ".join(cmd_args))
             return
 
         getattr(self.logger, log_lev)(" ".join(cmd_args))
@@ -89,5 +89,6 @@ class LCECCommand(EtherCATCommand):
             f"0x{subindex:02X}",
             str(value),
             f"--type={datatype.igh_type}",
+            log_lev="info",
             dry_run=dry_run,
         )

--- a/src/hw_device_mgr/lcec/tests/base_test_class.py
+++ b/src/hw_device_mgr/lcec/tests/base_test_class.py
@@ -41,7 +41,7 @@ class BaseLCECTestClass(BaseEtherCATTestClass):
         """
 
         def emulate_ethercat_command(args):
-            print(f'ethercat command: {" ".join(args)}')
+            print(f'mocking ethercat command: {" ".join(args)}')
             # Parse out args, kwargs
             assert args.pop(0) == "ethercat"
             cmd = args.pop(0)
@@ -55,7 +55,6 @@ class BaseLCECTestClass(BaseEtherCATTestClass):
                     k, v = (arg[2:], True)
                 kwargs[k] = v
                 args.pop(ix)
-            print("args:", args, "kwargs:", kwargs)
             # Emulate commands
             if cmd in ("upload", "download"):
                 ix = tuple(int(x, 16) for x in (args.pop(0), args.pop(0)))

--- a/src/hw_device_mgr/mgr/mgr.py
+++ b/src/hw_device_mgr/mgr/mgr.py
@@ -102,6 +102,7 @@ class HWDeviceMgr(FysomGlobalMixin, Device):
     def init_device_instances(self, **kwargs):
         for i, dev in enumerate(self.devices):
             dev.init(index=i, **kwargs)
+            self.logger.info(f"Adding device #{i}: {dev}")
 
     ####################################################
     # Drive state FSM


### PR DESCRIPTION
This fixes some bugs in updating device parameters:
- Fix a bug causing param values to be incorrectly written as `0`; add regression test
- Fix a bug parsing ESI files where object dictionary arrays were incorrectly expanded
- Misc. improvements to logger and test case output
