### PR TITLE
Zultron/2022 09 19 rebase for PRs: 3 minor core

### DIFF
--- a/hw_device_mgr/cia_301/command.py
+++ b/hw_device_mgr/cia_301/command.py
@@ -25,7 +25,9 @@ class CiA301Command(abc.ABC):
         """Scan bus, returning list of addresses and IDs for each device."""
 
     @abc.abstractmethod
-    def upload(self, address=None, index=None, subindex=0, datatype=None):
+    def upload(
+        self, address=None, index=None, subindex=0, datatype=None, **kwargs
+    ):
         """Upload a value from a device SDO."""
 
     @abc.abstractmethod
@@ -36,6 +38,7 @@ class CiA301Command(abc.ABC):
         subindex=0,
         value=None,
         datatype=None,
+        **kwargs,
     ):
         """Download a value to a device SDO."""
 

--- a/hw_device_mgr/cia_301/config.py
+++ b/hw_device_mgr/cia_301/config.py
@@ -108,7 +108,7 @@ class CiA301Config:
     # Param read/write
     #
 
-    def upload(self, sdo):
+    def upload(self, sdo, **kwargs):
         # Get SDO object
         sdo = self.sdo(sdo)
         res_raw = self.command().upload(
@@ -116,10 +116,11 @@ class CiA301Config:
             index=sdo.index,
             subindex=sdo.subindex,
             datatype=sdo.data_type,
+            **kwargs,
         )
         return sdo.data_type(res_raw)
 
-    def download(self, sdo, val, dry_run=False):
+    def download(self, sdo, val, dry_run=False, **kwargs):
         # Get SDO object
         sdo = self.sdo(sdo)
         # Check before setting value to avoid unnecessary NVRAM writes
@@ -128,6 +129,7 @@ class CiA301Config:
             index=sdo.index,
             subindex=sdo.subindex,
             datatype=sdo.data_type,
+            **kwargs,
         )
         if sdo.data_type(res_raw) == val:
             return  # SDO value already correct
@@ -140,6 +142,7 @@ class CiA301Config:
             subindex=sdo.subindex,
             value=val,
             datatype=sdo.data_type,
+            **kwargs,
         )
 
     #

--- a/hw_device_mgr/cia_402/device.py
+++ b/hw_device_mgr/cia_402/device.py
@@ -173,10 +173,10 @@ class CiA402Device(CiA301Device):
                 goal_reasons.append(f"state flag {flag_name} != {not flag_val}")
 
         if not goal_reached:
-            fb_out.update(
-                goal_reached=False, goal_reason="; ".join(goal_reasons)
-            )
-            self.logger.debug(f"Device {self.address}:  Goal not reached:")
+            goal_reason = "; ".join(goal_reasons)
+            fb_out.update(goal_reached=False, goal_reason=goal_reason)
+            if fb_out.changed("goal_reason"):
+                self.logger.debug(f"{self}:  Goal not reached: {goal_reason}")
         return fb_out
 
     state_bits = {

--- a/hw_device_mgr/cia_402/device.py
+++ b/hw_device_mgr/cia_402/device.py
@@ -492,13 +492,13 @@ class CiA402SimDevice(CiA402Device, CiA301SimDevice):
             # Log changes
             if self.sim_feedback.changed("control_mode_fb"):
                 cm = self.sim_feedback.get("control_mode_fb")
-                self.logger.info(f"{self} next control_mode_fb:  0x{cm:04X}")
+                self.logger.info(f"{self} sim control_mode_fb:  0x{cm:04X}")
             if self.sim_feedback.changed("status_word"):
                 sw = self.sim_feedback.get("status_word")
                 flags = ",".join(k for k, v in sw_flags.items() if v)
                 flags = f" flags:  {flags}" if flags else ""
                 self.logger.info(
-                    f"{self} sim next status_word:  0x{sw:04X} {state} {flags}"
+                    f"{self} sim status_word:  0x{sw:04X} {state} {flags}"
                 )
 
         return sfb

--- a/hw_device_mgr/device.py
+++ b/hw_device_mgr/device.py
@@ -95,6 +95,7 @@ class Device(abc.ABC):
 
     def read(self):
         """Read `feedback_in` from hardware interface."""
+        self._interfaces["feedback_in"].set()
 
     def get_feedback(self):
         """Process `feedback_in` and return `feedback_out` interface."""
@@ -369,7 +370,7 @@ class SimDevice(Device):
         """Read `feedback_in` from hardware interface."""
         super().read()
         sfb = self._interfaces["sim_feedback"].get()
-        self._interfaces["feedback_in"].set(**sfb)
+        self._interfaces["feedback_in"].update(**sfb)
 
     def set_sim_feedback(self):
         """Simulate feedback from command and feedback."""

--- a/hw_device_mgr/device.py
+++ b/hw_device_mgr/device.py
@@ -3,6 +3,8 @@ from importlib.resources import path as imp_path
 from .logging import Logging
 from .interface import Interface
 from .data_types import DataType
+from functools import cached_property
+import re
 
 
 class Device(abc.ABC):
@@ -36,7 +38,7 @@ class Device(abc.ABC):
         self.address = address
         self.init_interfaces()
 
-    def init(self, index=None):
+    def init(self):
         """
         Initialize device.
 
@@ -44,7 +46,7 @@ class Device(abc.ABC):
         outside the constructor.  Implementations should always call
         `super().init()`.
         """
-        self.index = index
+        pass
 
     @classmethod
     def merge_dict_attrs(cls, attr):
@@ -61,6 +63,21 @@ class Device(abc.ABC):
             assert not (set(res.keys()) & set(c_attr.keys()))
             res.update(c_attr)
         return res
+
+    slug_separator = "."
+
+    @cached_property
+    def addr_slug(self):
+        """
+        Return a slug generated from the device address.
+
+        The slug is computed by separating numeric components of the
+        device `address` string with the `slug_separator` character,
+        default `.`, e.g. `(0,5)` -> `0.5`.  This is intended to be
+        useful for inclusion into identifiers.
+        """
+        addr_prefix = re.sub(r"[^0-9]+", self.slug_separator, str(self.address))
+        return addr_prefix.strip(self.slug_separator)
 
     def init_interfaces(self):
         intfs = self._interfaces = dict()

--- a/hw_device_mgr/devices/device_xml/SV660_EOE_1Axis_V9.12.xml
+++ b/hw_device_mgr/devices/device_xml/SV660_EOE_1Axis_V9.12.xml
@@ -2093,6 +2093,28 @@
                     <Access>rw</Access>
                   </Flags>
                 </SubItem>
+		<!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                <SubItem>
+                  <SubIdx>6</SubIdx>
+                  <Name>Stop mode at S-ON OFF</Name>
+                  <Type>UINT</Type>
+                  <BitSize>16</BitSize>
+                  <BitOffs>96</BitOffs>
+                  <Flags>
+                    <Access>rw</Access>
+                  </Flags>
+                </SubItem>
+		<!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                <SubItem>
+                  <SubIdx>7</SubIdx>
+                  <Name>Stop mode at No. 2 fault</Name>
+                  <Type>INT</Type>
+                  <BitSize>16</BitSize>
+                  <BitOffs>112</BitOffs>
+                  <Flags>
+                    <Access>rw</Access>
+                  </Flags>
+                </SubItem>
                 <SubItem>
                   <SubIdx>8</SubIdx>
                   <Name>Stop mode at limit switch signal</Name>
@@ -2541,6 +2563,17 @@
                     <Access>rw</Access>
                   </Flags>
                 </SubItem>
+		<!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                <SubItem>
+                  <SubIdx>24</SubIdx>
+                  <Name>EtherCAT forced DO output logic in non-OP status</Name>
+                  <Type>UINT</Type>
+                  <BitSize>16</BitSize>
+                  <BitOffs>112</BitOffs>
+                  <Flags>
+                    <Access>rw</Access>
+                  </Flags>
+                </SubItem>
               </DataType>
               <DataType>
                 <Name>DT2005</Name>
@@ -2581,6 +2614,28 @@
                   <Type>UINT</Type>
                   <BitSize>16</BitSize>
                   <BitOffs>112</BitOffs>
+                  <Flags>
+                    <Access>rw</Access>
+                  </Flags>
+                </SubItem>
+		<!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                <SubItem>
+                  <SubIdx>8</SubIdx>
+                  <Name>Numerator of electronic gear ratio</Name>
+                  <Type>UDINT</Type>
+                  <BitSize>32</BitSize>
+                  <BitOffs>128</BitOffs>
+                  <Flags>
+                    <Access>rw</Access>
+                  </Flags>
+                </SubItem>
+		<!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                <SubItem>
+                  <SubIdx>10</SubIdx>
+                  <Name>Denominator of electronic gear ratio</Name>
+                  <Type>UDINT</Type>
+                  <BitSize>32</BitSize>
+                  <BitOffs>160</BitOffs>
                   <Flags>
                     <Access>rw</Access>
                   </Flags>
@@ -4841,6 +4896,17 @@
                     <Access>rw</Access>
                   </Flags>
                 </SubItem>
+		<!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                <SubItem>
+                  <SubIdx>3</SubIdx>
+                  <Name>Offline inertia autotuning selection</Name>
+                  <Type>UINT</Type>
+                  <BitSize>16</BitSize>
+                  <BitOffs>48</BitOffs>
+                  <Flags>
+                    <Access>rw</Access>
+                  </Flags>
+                </SubItem>
                 <SubItem>
                   <SubIdx>5</SubIdx>
                   <Name>Encoder ROM reading/writing</Name>
@@ -6923,6 +6989,24 @@
                       <DefaultValue>0</DefaultValue>
                     </Info>
                   </SubItem>
+		  <!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                  <SubItem>
+                    <Name>Stop mode at S-ON OFF</Name>
+                    <Info>
+                      <MinValue>-3</MinValue>
+                      <MaxValue>1</MaxValue>
+                      <DefaultValue>0</DefaultValue>
+                    </Info>
+                  </SubItem>
+		  <!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                  <SubItem>
+                    <Name>Stop mode at No. 2 fault</Name>
+                    <Info>
+                      <MinValue>-5</MinValue>
+                      <MaxValue>3</MaxValue>
+                      <DefaultValue>2</DefaultValue>
+                    </Info>
+                  </SubItem>
                   <SubItem>
                     <Name>Stop mode at limit switch signal</Name>
                     <Info>
@@ -7295,6 +7379,15 @@
                       <DefaultValue>0</DefaultValue>
                     </Info>
                   </SubItem>
+		  <!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                  <SubItem>
+                    <Name>EtherCAT forced DO output logic in non-OP status</Name>
+                    <Info>
+                      <MinValue>0</MinValue>
+                      <MaxValue>7</MaxValue>
+                      <DefaultValue>1</DefaultValue>
+                    </Info>
+                </SubItem>
                 </Info>
                 <Flags>
                   <Access>ro</Access>
@@ -7335,6 +7428,24 @@
                       <MinValue>0</MinValue>
                       <MaxValue>1280</MaxValue>
                       <DefaultValue>0</DefaultValue>
+                    </Info>
+                  </SubItem>
+		  <!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                  <SubItem>
+                    <Name>Numerator of electronic gear ratio</Name>
+                    <Info>
+                      <MinValue>0</MinValue>
+                      <MaxValue>4294967295</MaxValue>
+                      <DefaultValue>1</DefaultValue>
+                    </Info>
+                  </SubItem>
+		  <!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                  <SubItem>
+                    <Name>Denominator of electronic gear ratio</Name>
+                    <Info>
+                      <MinValue>0</MinValue>
+                      <MaxValue>4294967295</MaxValue>
+                      <DefaultValue>1</DefaultValue>
                     </Info>
                   </SubItem>
                   <SubItem>
@@ -9053,6 +9164,15 @@
                   </SubItem>
                   <SubItem>
                     <Name>Fault reset</Name>
+                    <Info>
+                      <MinValue>0</MinValue>
+                      <MaxValue>1</MaxValue>
+                      <DefaultValue>0</DefaultValue>
+                    </Info>
+                  </SubItem>
+		  <!-- Added by john@zultron.com from SV660N Advanced User Guide 20201020 -->
+                  <SubItem>
+                    <Name>Offline inertia autotuning selection</Name>
                     <Info>
                       <MinValue>0</MinValue>
                       <MaxValue>1</MaxValue>

--- a/hw_device_mgr/errors/device.py
+++ b/hw_device_mgr/errors/device.py
@@ -54,20 +54,26 @@ class ErrorDevice(Device):
 
     def get_feedback(self):
         fb_out = super().get_feedback()
-        if not fb_out.get("error_code"):
+        error_code = self.feedback_in.get("error_code")
+        if not error_code:
             self.feedback_out.update(**self.no_error)
             return fb_out
 
         error_info = self.error_descriptions().get(error_code, None)
         if error_info is None:
-            self.feedback_out.update(
+            fb_out.update(
                 description=f"Unknown error code {error_code}",
                 advice="Please consult with hardware vendor",
                 error_code=error_code,
             )
             return fb_out
-
-        self.feedback_out.update(error_code=error_code, **error_info)
+        else:
+            fb_out.update(error_code=error_code, **error_info)
+        if fb_out.changed("error_code"):
+            msg = "error code {}:  {}".format(
+                error_code, fb_out.get("description")
+            )
+            self.logger.error(msg)
         return fb_out
 
 

--- a/hw_device_mgr/errors/device.py
+++ b/hw_device_mgr/errors/device.py
@@ -16,11 +16,14 @@ class ErrorDevice(Device):
 
     device_error_dir = "device_err"
 
-    feedback_data_types = dict(error_code="uint32")
-    feedback_defaults = dict(
+    feedback_in_data_types = dict(error_code="uint32")
+    feedback_in_defaults = dict(error_code=0)
+
+    feedback_out_defaults = dict(
         error_code=0, description="No error", advice="No error"
     )
-    no_error = feedback_defaults
+
+    no_error = feedback_out_defaults
 
     data_type_class = DataType
 
@@ -49,22 +52,23 @@ class ErrorDevice(Device):
                     errs[int(err_code_str, 0)] = err_data
         return cls._error_descriptions[cls.name]
 
-    def set_feedback(self, error_code=0, **kwargs):
-        super().set_feedback(**kwargs)
-        if not error_code:
-            self.feedback.update(**self.no_error)
-            return
+    def get_feedback(self):
+        fb_out = super().get_feedback()
+        if not fb_out.get("error_code"):
+            self.feedback_out.update(**self.no_error)
+            return fb_out
 
         error_info = self.error_descriptions().get(error_code, None)
         if error_info is None:
-            self.feedback.update(
+            self.feedback_out.update(
                 description=f"Unknown error code {error_code}",
                 advice="Please consult with hardware vendor",
                 error_code=error_code,
             )
-            return
+            return fb_out
 
-        self.feedback.update(error_code=error_code, **error_info)
+        self.feedback_out.update(error_code=error_code, **error_info)
+        return fb_out
 
 
 class ErrorSimDevice(ErrorDevice, SimDevice):

--- a/hw_device_mgr/hal/data_types.py
+++ b/hw_device_mgr/hal/data_types.py
@@ -11,15 +11,22 @@ class HALDataType(DataType, HALMixin):
         int8=dict(hal_type=HALMixin.HAL_S32),
         int16=dict(hal_type=HALMixin.HAL_S32),
         int32=dict(hal_type=HALMixin.HAL_S32),
-        int64=dict(hal_type=HALMixin.HAL_S64),
         uint8=dict(hal_type=HALMixin.HAL_U32),
         uint16=dict(hal_type=HALMixin.HAL_U32),
         uint32=dict(hal_type=HALMixin.HAL_U32),
-        uint64=dict(hal_type=HALMixin.HAL_U64),
         float=dict(hal_type=HALMixin.HAL_FLOAT),
         double=dict(hal_type=HALMixin.HAL_FLOAT),
         # No HAL_STR type
     )
+    have_64 = hasattr(HALMixin, "HAL_S64")
+    if have_64:
+        # Machinekit HAL has 64-bit int types, but not LCNC
+        subtype_data.update(
+            dict(
+                int64=dict(hal_type=HALMixin.HAL_S64),
+                uint64=dict(hal_type=HALMixin.HAL_U64),
+            )
+        )
 
     @classmethod
     def hal_type_str(cls):

--- a/hw_device_mgr/hal/tests/test_data_types.py
+++ b/hw_device_mgr/hal/tests/test_data_types.py
@@ -20,6 +20,11 @@ class TestHALDataType(BaseHALTestClass, _TestDataType):
 
     def test_hal_type_str(self):
         for shared_name, exp_str in self.sname_to_typestr.items():
+            if shared_name not in self.data_type_class.subtype_data:
+                # LinuxCNC HAL doesn't have 64-bit int types
+                assert shared_name.endswith("64")
+                print(f"Skipping 64-bit int type {shared_name}")
+                continue
             cls = self.data_type_class.by_shared_name(shared_name)
             exp_int = self.data_type_class.hal_enum(exp_str[4:])
             cls_str, cls_int = (cls.hal_type_str(), cls.hal_type)

--- a/hw_device_mgr/lcec/command.py
+++ b/hw_device_mgr/lcec/command.py
@@ -121,10 +121,11 @@ class LCECCommand(EtherCATCommand):
             "download",
             f"--master={address[0]}",
             f"--position={address[1]}",
+            f"--type={datatype.igh_type}",
+            "--",
             f"0x{index:04X}",
             f"0x{subindex:02X}",
             str(value),
-            f"--type={datatype.igh_type}",
             log_lev="info",
             **kwargs,
         )

--- a/hw_device_mgr/lcec/command.py
+++ b/hw_device_mgr/lcec/command.py
@@ -103,10 +103,12 @@ class LCECCommand(EtherCATCommand):
             f"--type={datatype.igh_type}",
             **kwargs,
         )
-        # FIXME Handle non-int types
-        val_hex, val = output[0].split(" ", 1)
-        val = int(val, 10)
-        return val
+        if datatype.shared_name == "str":
+            return output[0]
+        else:
+            val_hex, val = output[0].split(" ", 1)
+            val = int(val, 10)
+            return val
 
     def download(
         self,

--- a/hw_device_mgr/lcec/command.py
+++ b/hw_device_mgr/lcec/command.py
@@ -17,7 +17,9 @@ class LCECCommand(EtherCATCommand):
     def _parse_output(cls, resp, kwargs):
         return resp
 
-    def _ethercat(self, *args, log_lev="debug", dry_run=False):
+    def _ethercat(
+        self, *args, log_lev="debug", dry_run=False, stderr_to_devnull=False
+    ):
         """
         Run IgH EtherCAT Master `ethercat` utility.
 
@@ -30,8 +32,9 @@ class LCECCommand(EtherCATCommand):
             return
 
         getattr(self.logger, log_lev)(" ".join(cmd_args))
+        stderr = subprocess.DEVNULL if stderr_to_devnull else None
         try:
-            resp = subprocess.check_output(cmd_args)
+            resp = subprocess.check_output(cmd_args, stderr=stderr)
         except subprocess.CalledProcessError as e:
             raise EtherCATCommandException(str(e))
 
@@ -40,10 +43,12 @@ class LCECCommand(EtherCATCommand):
 
     _device_location_re = re.compile(r"=== Master ([0-9]), Slave ([0-9]+) ")
 
-    def scan_bus(self, bus=None):
+    def scan_bus(self, bus=None, **kwargs):
         bus = self.default_bus if bus is None else bus
         devices = list()
-        output = self._ethercat("slaves", f"--master={bus}", "--verbose")
+        output = self._ethercat(
+            "slaves", f"--master={bus}", "--verbose", **kwargs
+        )
         for line in output:
             line = line.strip()
             if line.startswith("==="):
@@ -84,7 +89,9 @@ class LCECCommand(EtherCATCommand):
         else:
             return None
 
-    def upload(self, address=None, index=None, subindex=0, datatype=None):
+    def upload(
+        self, address=None, index=None, subindex=0, datatype=None, **kwargs
+    ):
         index = self.data_type_class.uint16(index)
         subindex = self.data_type_class.uint16(subindex)
         output = self._ethercat(
@@ -94,6 +101,7 @@ class LCECCommand(EtherCATCommand):
             f"0x{index:04X}",
             f"0x{subindex:02X}",
             f"--type={datatype.igh_type}",
+            **kwargs,
         )
         # FIXME Handle non-int types
         val_hex, val = output[0].split(" ", 1)
@@ -107,7 +115,7 @@ class LCECCommand(EtherCATCommand):
         subindex=0,
         value=None,
         datatype=None,
-        dry_run=False,
+        **kwargs,
     ):
         self._ethercat(
             "download",
@@ -118,7 +126,7 @@ class LCECCommand(EtherCATCommand):
             str(value),
             f"--type={datatype.igh_type}",
             log_lev="info",
-            dry_run=dry_run,
+            **kwargs,
         )
 
 

--- a/hw_device_mgr/lcec/data_types.py
+++ b/hw_device_mgr/lcec/data_types.py
@@ -18,5 +18,5 @@ class LCECDataType(EtherCATDataType, HALDataType):
         uint64=dict(igh_type="uint64"),
         float=dict(igh_type="float"),
         double=dict(igh_type="double"),
-        # Strings not usable by `ethercat` tool
+        str=dict(igh_type="string"),
     )

--- a/hw_device_mgr/lcec/data_types.py
+++ b/hw_device_mgr/lcec/data_types.py
@@ -11,12 +11,18 @@ class LCECDataType(EtherCATDataType, HALDataType):
         int8=dict(igh_type="int8"),
         int16=dict(igh_type="int16"),
         int32=dict(igh_type="int32"),
-        int64=dict(igh_type="int64"),
         uint8=dict(igh_type="uint8"),
         uint16=dict(igh_type="uint16"),
         uint32=dict(igh_type="uint32"),
-        uint64=dict(igh_type="uint64"),
         float=dict(igh_type="float"),
         double=dict(igh_type="double"),
         str=dict(igh_type="string"),
     )
+    if HALDataType.have_64:
+        # Machinekit HAL has 64-bit int types, but not LCNC
+        subtype_data.update(
+            dict(
+                int64=dict(igh_type="int64"),
+                uint64=dict(igh_type="uint64"),
+            )
+        )

--- a/hw_device_mgr/lcec/tests/base_test_class.py
+++ b/hw_device_mgr/lcec/tests/base_test_class.py
@@ -45,8 +45,9 @@ class BaseLCECTestClass(BaseEtherCATTestClass, BaseHALTestClass):
         commands.  Patches `subprocess.check_output()`.
         """
 
-        def emulate_ethercat_command(args):
+        def emulate_ethercat_command(args, **kwargs):
             print(f'mocking command: {" ".join(args)}')
+            print(f"  subprocess.check_output kwargs: {repr(kwargs)}")
             # Parse out args, kwargs
             assert args.pop(0) == "ethercat"
             cmd = args.pop(0)

--- a/hw_device_mgr/lcec/tests/test_data_types.py
+++ b/hw_device_mgr/lcec/tests/test_data_types.py
@@ -25,6 +25,11 @@ class TestLCECDataType(
 
     def test_igh_type_attr(self):
         for shared_name in self.defined_shared_types:
+            if shared_name not in self.data_type_class.subtype_data:
+                # LinuxCNC HAL doesn't have 64-bit int types
+                assert shared_name.endswith("64")
+                print(f"Skipping 64-bit int type {shared_name}")
+                continue
             cls = self.data_type_class.by_shared_name(shared_name)
             print("cls:", cls)
             assert hasattr(cls, "igh_type")

--- a/hw_device_mgr/lcec/tests/test_device.py
+++ b/hw_device_mgr/lcec/tests/test_device.py
@@ -19,7 +19,7 @@ class TestLCECDevice(BaseLCECTestClass, _TestEtherCATDevice, _TestHALDevice):
     ]
 
     @pytest.fixture
-    def obj(self, device_cls, sim_device_data, sdo_data, mock_halcomp):
+    def obj(self, sim_device_data, mock_halcomp):
         self.obj = self.device_model_cls(
             address=sim_device_data["test_address"]
         )

--- a/hw_device_mgr/mgr/mgr.py
+++ b/hw_device_mgr/mgr/mgr.py
@@ -402,7 +402,7 @@ class HWDeviceMgr(FysomGlobalMixin, Device):
     ####################################################
     # Execution
 
-    def run(self):
+    def run_loop(self):
         """Program main loop."""
         update_period = 1.0 / self.mgr_config.get("update_rate", 10.0)
         while not self.shutdown:
@@ -423,6 +423,21 @@ class HWDeviceMgr(FysomGlobalMixin, Device):
                 self.fast_track = False
                 continue
             time.sleep(update_period)
+
+    def run(self):
+        """Program main."""
+        try:
+            self.run_loop()
+        except KeyboardInterrupt:
+            self.logger.info("Exiting at keyboard interrupt")
+            return 0
+        except Exception:
+            self.logger.error("Exiting at unrecoverable exception:")
+            for line in traceback.format_exc().splitlines():
+                self.logger.error(line)
+            return 1
+        self.logger.info("Exiting")
+        return 0
 
     def read_update_write(self):
         """

--- a/hw_device_mgr/mgr/mgr.py
+++ b/hw_device_mgr/mgr/mgr.py
@@ -15,6 +15,7 @@ class HWDeviceMgr(FysomGlobalMixin, Device):
     data_type_class = CiA402Device.data_type_class
     device_base_class = CiA402Device
     device_classes = None
+    slug_separator = ""
 
     @classmethod
     def device_model_id(cls):
@@ -89,7 +90,7 @@ class HWDeviceMgr(FysomGlobalMixin, Device):
 
     def init_device_instances(self, **kwargs):
         for i, dev in enumerate(self.devices):
-            dev.init(index=i, **kwargs)
+            dev.init(**kwargs)
             self.logger.info(f"Adding device #{i}: {dev}")
 
     ####################################################

--- a/hw_device_mgr/tests/base_test_class.py
+++ b/hw_device_mgr/tests/base_test_class.py
@@ -39,7 +39,9 @@ class BaseTestClass:
             assert dmc.name
             if dmc.test_category == test_category:
                 return dmc
-        raise ValueError(f"No device in test category class '{test_category}'")
+        raise ValueError(
+            f"{cls}:  No device in test category class '{test_category}'"
+        )
 
     @classmethod
     def munge_sim_device_data(cls, sim_device_data):

--- a/hw_device_mgr/tests/test_device.py
+++ b/hw_device_mgr/tests/test_device.py
@@ -122,7 +122,7 @@ class TestDevice(BaseTestClass):
         yield self.obj
 
     def test_init(self, obj):
-        assert hasattr(obj, "index")
+        pass  # Base class init() method does nothing
 
     def test_set_sim_feedback(self, obj):
         res = obj.set_sim_feedback()

--- a/hw_device_mgr/tests/test_device.py
+++ b/hw_device_mgr/tests/test_device.py
@@ -352,7 +352,7 @@ class TestDevice(BaseTestClass):
 
     def test_dot(self, tmp_path):
         # Test class diagram
-        gv_file = tmp_path / ".." / f"{self.device_class.category}.gv"
+        gv_file = tmp_path / f"{self.device_class.category}.gv"
         assert not gv_file.exists()
         with gv_file.open("w") as f:
             f.write(self.device_class.dot())


### PR DESCRIPTION
This is 3 of 9 in a series of PRs refactoring the `hw_device_mgr` to run outside ROS, handle file resources more intelligently, manage PDO configurations, improve abstraction, improve CiA402 homing, simplify initialization, fix a `state_cmd` race condition, and other fixes and improvements.

This PR is based on & should be merged after #15 .

This third PR makes minor changes to core code; these shouldn't change the external API (but still could introduce unexpected breakage).

New features:
- Add method to dump values of entire object tree from a device
- Update HAL to work with LinuxCNC HAL (with no 64-bit `int` support)
- Add error data for Inovance drives

Fixes:
- Fix manager problems by resetting `feedback_in` interface in the `read()` method
- Fix setting negative `int` type & reading `str` type parameter data
- Catch `KeyboardInterrupt` in non-ROS manager run loop
- Clean up & fix `device_config` reading routines
- Misc. console output tweaks
- Fix broken `errors` code
- Fix HAL pin name generation
- Fix graphviz test
